### PR TITLE
ENH: add reuse_port option in create_socket function

### DIFF
--- a/asyncudp/__init__.py
+++ b/asyncudp/__init__.py
@@ -105,7 +105,7 @@ class Socket:
         self.close()
 
 
-async def create_socket(local_addr=None, remote_addr=None, packets_queue_max_size=0):
+async def create_socket(local_addr=None, remote_addr=None, packets_queue_max_size=0, reuse_port=None):
     """Create a UDP socket with given local and remote addresses.
 
     >>> sock = await asyncudp.create_socket(local_addr=('127.0.0.1', 9999))
@@ -116,6 +116,7 @@ async def create_socket(local_addr=None, remote_addr=None, packets_queue_max_siz
     transport, protocol = await loop.create_datagram_endpoint(
         lambda: _SocketProtocol(packets_queue_max_size),
         local_addr=local_addr,
-        remote_addr=remote_addr)
+        remote_addr=remote_addr,
+        reuse_port=reuse_port)
 
     return Socket(transport, protocol)

--- a/tests/test_asyncudp.py
+++ b/tests/test_asyncudp.py
@@ -131,3 +131,13 @@ class AsyncudpTest(unittest.TestCase):
 
         server.close()
         client.close()
+
+    def test_create_socket_reuse_port(self):
+        asyncio.run(self.create_socket_reuse_port())
+
+    async def create_socket_reuse_port(self):
+        sock = await asyncudp.create_socket(local_addr=('127.0.0.1', 13003), reuse_port=True)
+        sock.close()
+        sock2 = await asyncudp.create_socket(local_addr=('127.0.0.1', 13003), reuse_port=True)
+        sock2.close()
+        


### PR DESCRIPTION
Useful when you want to avoid 'Address already in use' error