### PR TITLE
Update CI release to produce wheels

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,10 +39,10 @@ jobs:
     - name: Install pypa/build
       run: |
         python -m pip install build --user
-    - name: Build a source tarball
+    - name: Build a source tarball and binary 
       run: |
         git clean -dfx
-        python -m build --sdist --outdir dist/ .
+        python -m build --outdir dist/ .
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:


### PR DESCRIPTION
In addition to create source distributions, also create a wheel binary file so clients don't have to. Speeds up user installation.